### PR TITLE
CB-1221: Change the heading link to `/resouces`

### DIFF
--- a/parts/uplift-logo.php
+++ b/parts/uplift-logo.php
@@ -10,5 +10,5 @@
 </script>
 
 <div class="uplift-logo-container">
-  <h1><a href="/">Uplift Blog</a></h1>
+  <h1><a href="/resources/">Uplift Blog</a></h1>
 </div>


### PR DESCRIPTION
The blog is no longer on `blog.caringbridge.org` and is instead
in a sub path of `caringbridge.org` so linking to `/` was causing
this link to go to the homepage instead of the blog home.
